### PR TITLE
Fix dot to comma issue in some (german) browsers

### DIFF
--- a/components/dom/domhandler.ts
+++ b/components/dom/domhandler.ts
@@ -170,11 +170,13 @@ export class DomHandler {
         element.style.opacity = 0;
 
         let last = +new Date();
+        let opacity = 0;
         let tick = function () {
-            element.style.opacity = +element.style.opacity + (new Date().getTime() - last) / duration;
+            opacity = +element.style.opacity + (new Date().getTime() - last) / duration;
+            element.style.opacity = opacity;
             last = +new Date();
 
-            if (+element.style.opacity < 1) {
+            if (+opacity < 1) {
                 (window.requestAnimationFrame && requestAnimationFrame(tick)) || setTimeout(tick, 16);
             }
         };


### PR DESCRIPTION
I had some issues with fading. i found out that in some of my browsers and in electron the value of opacity will have a comma instead of a dot as float separator. thats common for germany, because we write floats with comma instead of dot. maybe the local settings of the browser cause this issue but this code version is more stable in any case.